### PR TITLE
Removed a="asd" attribute from Tag attribute key tag

### DIFF
--- a/Welded Light.tmTheme
+++ b/Welded Light.tmTheme
@@ -230,7 +230,7 @@
 			</dict>
 		</dict>
 		<dict>
-			<key a="asd">name</key>
+			<key>name</key>
 			<string>Tag attribute</string>
 			<key>scope</key>
 			<string>entity.other.attribute-name</string>

--- a/Welded.tmTheme
+++ b/Welded.tmTheme
@@ -230,7 +230,7 @@
 			</dict>
 		</dict>
 		<dict>
-			<key a="asd">name</key>
+			<key>name</key>
 			<string>Tag attribute</string>
 			<key>scope</key>
 			<string>entity.other.attribute-name</string>


### PR DESCRIPTION
Hi!

First of all, thank you for making and sharing this nice theme!

I've found a minor issue while trying to convert the version available in Colorsublime repo. This seems to be the original repo for this theme, so I've though of sharing PR here as well.

Key tag for `Tag attribute` contains extra `a="asd"` attribute which is not valid according to plist dtd (key tags shouldn't have any attributes). Although this seems Sublime ignores this attribute and theme works just fine, this extra attribute causes problems when validating XML or using `fast-plist` to parse the file.